### PR TITLE
Fixed YAML desearilization bug in neovision

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -31,7 +31,7 @@ except:
 
 # Load config
 with open(CWD + '/config/config.yml') as f:
-    config = yaml.load(f, Loader=yaml.FullLoader)
+    config = yaml.load(f, Loader=yaml.SafeLoader)
 
     def fixuml(x):
         '''Fix wrong coding of äüö (German language only)'''
@@ -44,7 +44,7 @@ with open(CWD + '/config/config.yml') as f:
     client = commands.Bot(command_prefix = config['main']['prefix'])
 
 with open(CWD + '/data/dailycoins.yml') as f:
-    daily = yaml.load(f, Loader=yaml.FullLoader)
+    daily = yaml.load(f, Loader=yaml.SafeLoader)
 
 # Bot
 @client.event


### PR DESCRIPTION
### 📊 Metadata *

Insecure YAML deserialization
#### Bounty URL:  https://www.huntr.dev/bounties/1-other-neovision

### ⚙️ Description *

`Neovision` is a coin system for Discord with an API, this package is vulnerable for `Arbitrary Code Execution`

### 💻 Technical Description *

Vulnerable to YAML deserialization attack caused by unsafe loading.

### 🐛 Proof of Concept (POC) *

`config/config.yaml`
```yaml
payload = """cmd: !!python/object/new:type
  args: ["z", !!python/tuple [], {"extend": !!python/name:exec }]
  listitems: "__import__('os').system('xcalc')"
"""
```

Just update the above-mentioned file and start `python src/bot.py`, code is executed and `xcalc` will be popped.

![image](https://user-images.githubusercontent.com/16708391/108906724-35a9ad00-7647-11eb-9431-bdd218539044.png)


### 🔥 Proof of Fix (PoF) *

Used a safer loader(SafeLoader) instead of `FullLoader`.

The issue is fixed, and hence no code is executed.


### 👍 User Acceptance Testing (UAT)

All Ok, No breaking changes introduced.  :)